### PR TITLE
ci: publish to npm on GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # npm provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      # prepublishOnly runs lint + the full test suite before this publishes.
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds a release-triggered npm publish workflow so releases don't depend on local npm auth.

- Triggers when a GitHub release is **published** (or manually via *Run workflow*)
- Builds, then `npm publish --provenance` — `prepublishOnly` runs lint + the full test suite as a gate
- Provenance gives the package a verified "built from this repo" badge on npmjs.com

**One-time setup required before merging is useful:** add an `NPM_TOKEN` repo secret — npmjs.com → *Access Tokens* → *Generate New Token* → **Automation** (bypasses OTP), then:

```
gh secret set NPM_TOKEN
```

Once merged and the secret is set, publishing v2.0.1 (already tagged) is just: create the GitHub release for `v2.0.1` and the workflow does the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)