### PR TITLE
feat: optional loadNetwork(url) — fetch the network at runtime instead of only bundling it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `loadNetwork(url, options?)` — optionally fetch the maritime network from a
+  URL (CDN/host) at runtime and pass it via the existing `network` option,
+  instead of using the bundled copy. Non-breaking: the bundled network stays
+  the default and `seaRoute` remains synchronous. The network is also published
+  as a CORS-enabled asset on the demo's GitHub Pages site
+  (`/searoute-ts/marnet.json`).
+
 ## 2.0.1 — 2026-07-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ const alts = seaRouteAlternatives(shanghai, rotterdam, { k: 4 });
 //  no-suez-no-panama  25 845 km (via Cape of Good Hope)
 ```
 
+### Fetch the network from a URL instead of bundling it (optional)
+
+The network is bundled by default, so `seaRoute` works offline with zero setup.
+If you'd rather **not** ship the ~1 MB network (e.g. to trim a browser bundle,
+or to use an updated network without upgrading the package), fetch it at
+runtime and pass it via the existing `network` option:
+
+```ts
+import { seaRoute, loadNetwork } from 'searoute-ts';
+
+// CORS-enabled, served from GitHub Pages (or point at your own host / a CDN).
+const network = await loadNetwork('https://mayurrawte.github.io/searoute-ts/marnet.json');
+
+const route = seaRoute(shanghai, rotterdam, { network });
+```
+
+Only the fetch is async — `seaRoute` itself stays synchronous. `loadNetwork`
+uses the global `fetch` (Node ≥18 and all browsers); pass `{ fetch }` to supply
+your own. This is purely opt-in; nothing changes if you don't use it.
+
 ## Output shape
 
 ```ts
@@ -209,6 +229,7 @@ import {
   seaRoute,                  // single shortest route
   seaRouteMulti,             // ordered waypoints (multi-leg)
   seaRouteAlternatives,      // K-shortest alternatives
+  loadNetwork,               // optional: fetch a network from a URL/CDN
   CANAL_MAX_DRAFT_M,         // { panama: 15.2, suez: 20.1, kiel: 7, corinth: 7.3 }
   DEFAULT_MARNET,            // bundled FeatureCollection<LineString>
   PASSAGE_BBOXES,            // passage bbox lookup
@@ -220,6 +241,7 @@ import {
   type SeaRouteOptions,
   type SeaRouteFeature,
   type SeaRouteProperties,
+  type LoadNetworkOptions,
   type MarnetNetwork,
   type MarnetProperties,
 } from 'searoute-ts';

--- a/README.md
+++ b/README.md
@@ -130,6 +130,37 @@ Only the fetch is async — `seaRoute` itself stays synchronous. `loadNetwork`
 uses the global `fetch` (Node ≥18 and all browsers); pass `{ fetch }` to supply
 your own. This is purely opt-in; nothing changes if you don't use it.
 
+#### Which option should I use?
+
+| Approach | How | Data version | Works offline | Best for |
+|----------|-----|--------------|---------------|----------|
+| **Bundled** (default) | `seaRoute(a, b)` — no `network` | pinned to your installed package | ✅ | Most users; zero config, deterministic |
+| **Latest via URL** | `loadNetwork('…/marnet.json')` | always the newest hosted | ❌ needs network | Always-current data without upgrading |
+| **Pinned via CDN** | `loadNetwork('https://cdn.jsdelivr.net/npm/searoute-ts@2.0.1/…')` | frozen (immutable) | ❌ needs network | Reproducible builds |
+
+#### Versioning the hosted network
+
+You choose the version by choosing the **URL**:
+
+- **`@latest` / rolling** — the GitHub Pages URL above always serves the current
+  network. Convenient, but it can change under you.
+- **Pinned & immutable** — because the package is on npm, **jsDelivr** and
+  **unpkg** serve every published version automatically, with immutable
+  per-version URLs:
+
+  ```
+  https://cdn.jsdelivr.net/npm/searoute-ts@latest/dist/marnet.json   # newest
+  https://cdn.jsdelivr.net/npm/searoute-ts@2/dist/marnet.json        # newest 2.x
+  https://cdn.jsdelivr.net/npm/searoute-ts@2.0.1/dist/marnet.json    # frozen
+  ```
+
+  A pinned URL never changes, so your routes stay reproducible. (These
+  standalone-JSON CDN paths land with the package once the network ships as a
+  separate asset — see issue #10; until then, use the GitHub Pages URL.)
+
+For production, prefer a **pinned** URL (or just the bundled default) so your
+distances don't shift when the network is updated.
+
 ## Output shape
 
 ```ts

--- a/examples/web-demo/.gitignore
+++ b/examples/web-demo/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 *.log
 .vite
+public/marnet.json

--- a/examples/web-demo/package.json
+++ b/examples/web-demo/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/emit-marnet.mjs",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run"

--- a/examples/web-demo/scripts/emit-marnet.mjs
+++ b/examples/web-demo/scripts/emit-marnet.mjs
@@ -1,0 +1,16 @@
+// Writes the bundled network to public/marnet.json so the GitHub Pages deploy
+// serves it as a CORS-enabled reference URL for `loadNetwork()`. Generated at
+// build time (not committed) — see the demo .gitignore.
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { DEFAULT_MARNET } from 'searoute-ts';
+
+const demoDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = join(demoDir, 'public');
+mkdirSync(outDir, { recursive: true });
+
+const out = join(outDir, 'marnet.json');
+writeFileSync(out, JSON.stringify(DEFAULT_MARNET));
+console.log(`wrote ${out} (${DEFAULT_MARNET.features.length} features)`);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,6 +4,7 @@ import type { Feature, Point } from 'geojson';
 import {
   CANAL_MAX_DRAFT_M,
   clearFinderCache,
+  loadNetwork,
   NoRouteError,
   seaRoute,
   seaRouteAlternatives,
@@ -477,4 +478,62 @@ test('custom network option is honoured', (t) => {
   const r = seaRoute([-74, 40], [0, 51], { units: 'kilometers', network: customNet });
   t.is(r.geometry.coordinates.length, 3);
   t.true(r.properties.length > 5000 && r.properties.length < 8000);
+});
+
+// ── loadNetwork (optional remote/CDN loader) ────────────────────────────────
+
+const ATLANTIC_NET = {
+  type: 'FeatureCollection' as const,
+  features: [
+    {
+      type: 'Feature' as const,
+      properties: {},
+      geometry: {
+        type: 'LineString' as const,
+        coordinates: [
+          [-74, 40],
+          [-30, 45],
+          [0, 51],
+        ],
+      },
+    },
+  ],
+};
+
+function fakeResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+test('loadNetwork fetches a network and returns it usable by seaRoute', async (t) => {
+  let requested = '';
+  const stub = (async (url: string) => {
+    requested = String(url);
+    return fakeResponse(ATLANTIC_NET);
+  }) as unknown as typeof fetch;
+
+  const network = await loadNetwork('https://cdn.example.com/marnet.json', { fetch: stub });
+
+  t.is(requested, 'https://cdn.example.com/marnet.json');
+  t.is(network.type, 'FeatureCollection');
+  const route = seaRoute([-74, 40], [0, 51], { units: 'kilometers', network });
+  t.is(route.geometry.coordinates.length, 3);
+});
+
+test('loadNetwork throws a clear error on a non-OK response', async (t) => {
+  const stub = (async () =>
+    fakeResponse({}, { ok: false, status: 404 })) as unknown as typeof fetch;
+  await t.throwsAsync(loadNetwork('https://cdn.example.com/missing.json', { fetch: stub }), {
+    message: /404/,
+  });
+});
+
+test('loadNetwork rejects payloads that are not a GeoJSON FeatureCollection', async (t) => {
+  const stub = (async () => fakeResponse({ type: 'Nope' })) as unknown as typeof fetch;
+  await t.throwsAsync(loadNetwork('https://cdn.example.com/bad.json', { fetch: stub }), {
+    message: /FeatureCollection/,
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,6 +356,59 @@ export function seaRouteAlternatives(
   });
 }
 
+/** Options for {@link loadNetwork}. */
+export type LoadNetworkOptions = {
+  /**
+   * Custom fetch implementation. Defaults to the global `fetch` (available on
+   * Node ≥18, which this package requires, and in all browsers). Pass one for
+   * older runtimes or to inject auth/proxy behaviour.
+   */
+  fetch?: typeof fetch;
+};
+
+/**
+ * Fetch a maritime network from a URL, for use with the `network` option.
+ *
+ * The bundled network (`DEFAULT_MARNET`) stays the default — this is purely
+ * opt-in, for consumers who prefer to fetch the network from a CDN/host (to
+ * trim their bundle, or to use an updated network without upgrading the
+ * package) instead of shipping the embedded copy. `seaRoute` itself remains
+ * synchronous and offline; only the network fetch is async.
+ *
+ * ```ts
+ * const network = await loadNetwork('https://mayurrawte.github.io/searoute-ts/marnet.json');
+ * const route = seaRoute(origin, destination, { network });
+ * ```
+ *
+ * @throws {Error} on a non-OK HTTP response, or when the payload is not a
+ *   GeoJSON `FeatureCollection`.
+ */
+export async function loadNetwork(
+  url: string,
+  options: LoadNetworkOptions = {},
+): Promise<MarnetNetwork> {
+  const doFetch = options.fetch ?? globalThis.fetch;
+  if (typeof doFetch !== 'function') {
+    throw new Error(
+      'loadNetwork: no fetch implementation available — pass options.fetch on runtimes without a global fetch',
+    );
+  }
+  const res = await doFetch(url);
+  if (!res.ok) {
+    throw new Error(`loadNetwork: failed to fetch ${url} (HTTP ${res.status})`);
+  }
+  const data = (await res.json()) as unknown;
+  if (
+    !data ||
+    typeof data !== 'object' ||
+    (data as { type?: unknown }).type !== 'FeatureCollection' ||
+    !Array.isArray((data as { features?: unknown }).features)
+  ) {
+    throw new Error(`loadNetwork: ${url} is not a GeoJSON FeatureCollection`);
+  }
+  return data as MarnetNetwork;
+}
+
 // ── Internal helpers ────────────────────────────────────────────────────────
 
 function unitToKm(u: Units): number {


### PR DESCRIPTION
Implements #16. **Non-breaking / additive** — the bundled network stays the default and `seaRoute` remains synchronous and offline. Nothing changes for existing users.

## What
- **`loadNetwork(url, options?)`** — async helper that fetches a maritime network and returns it for the existing `network` option:
  ```ts
  const network = await loadNetwork('https://mayurrawte.github.io/searoute-ts/marnet.json');
  const route = seaRoute(origin, destination, { network });
  ```
  Uses global `fetch` (Node ≥18, which the package already requires, and browsers); accepts a `{ fetch }` override. Throws clearly on non-OK responses and on payloads that aren't a GeoJSON `FeatureCollection`.
- **Hosted reference asset** — the demo build now emits `public/marnet.json` (generated, gitignored, not committed) so the existing GitHub Pages deploy serves it at `https://mayurrawte.github.io/searoute-ts/marnet.json`, CORS-enabled. Available after this merges and the Pages workflow runs.
- README section + API-reference entry + CHANGELOG (Unreleased). No version bump.

## Why
Lets consumers who want to trim their bundle (or use an updated network without upgrading the package) fetch the ~1 MB network from a CDN/host, while everyone else keeps the zero-config bundled default. Complements #10 (which will also make `dist/marnet.json` available via jsDelivr/unpkg automatically).

## Validation
- TDD: 3 new tests for `loadNetwork` (success + usable in `seaRoute`, non-OK → throws, non-FeatureCollection → throws).
- `npm run lint`, `npm run format:check`, `npm run build`, `npm test` → **47 tests pass**.
- Demo: `npm run build` emits `dist/marnet.json` (1.1 MB) and builds successfully.