### PR TITLE
feat: add antimeridian output option for dateline-crossing routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   the default and `seaRoute` remains synchronous. The network is also published
   as a CORS-enabled asset on the demo's GitHub Pages site
   (`/searoute-ts/marnet.json`).
+- `antimeridian` option on `seaRoute` / `seaRouteMulti` for map-ready output of
+  routes crossing the ±180° dateline. `'unwrap'` returns one continuous
+  `LineString` (longitudes may exceed ±180°, ideal for MapLibre/Leaflet/Deck.gl);
+  `'split'` returns a `MultiLineString` cut at ±180° (RFC 7946-friendly). Default
+  is unchanged (wrapped `LineString`). New `Antimeridian` and
+  `SeaRouteMultiFeature` exports. (#9)
 
 ### Changed
 - The Eurostat network is no longer inlined into each build. It now ships once

--- a/DOCS.md
+++ b/DOCS.md
@@ -28,6 +28,8 @@ A common bug in maritime networks stored in `[-180, 180]` lon/lat space is that 
 
 At data-conversion time, every vertex with `lon === 180` is rewritten to `lon === -180`. Now both sides converge to a single graph vertex. The edge-weight function uses haversine distance, which is correct across the antimeridian, so route lengths stay accurate.
 
+A consequence is that a route which crosses the Pacific comes back wrapped to `[-180, 180]`, so a segment can jump from `+179` to `-179`. Renderers that draw straight lines between vertices then streak a route across the whole map. Pass the `antimeridian` option to fix the *output* geometry: `'unwrap'` shifts longitudes by multiples of 360° into one continuous `LineString`, and `'split'` cuts the route into a `MultiLineString` at ±180°. The default leaves the geometry wrapped (no change). Route length is unaffected — it is computed from the geodesic path before any representation change.
+
 ### Other resolutions
 
 Eurostat ships 5 km / 10 km / 20 km / 50 km / 100 km networks. We bundle only 100 km to keep the package small. For higher resolution, use the `network` option — see [Custom networks](#custom-networks).

--- a/README.md
+++ b/README.md
@@ -194,10 +194,27 @@ seaRoute(origin, destination, {
   returnPassages:          true,                     // populate properties.passages
   maxSnapDistanceKm:       50,                       // SnapFailedError if exceeded
   network:                 customMarnet,             // BYO FeatureCollection
+  antimeridian:            'split',                  // 'unwrap' | 'split' dateline handling
 });
 ```
 
 Inputs can be `[lon, lat]` arrays, GeoJSON `Feature<Point>`, or bare `Point` objects.
+
+### Antimeridian (dateline) handling
+
+Routes that cross the ±180° meridian (e.g. Yokohama → LA) come back wrapped to
+`[-180, 180]` by default, which many map renderers draw as a straight streak
+across the whole map. Pass `antimeridian` to get map-ready geometry:
+
+```ts
+seaRoute(yokohama, la, { antimeridian: 'unwrap' }); // continuous LineString (may exceed ±180)
+seaRoute(yokohama, la, { antimeridian: 'split' });  // MultiLineString cut at ±180 (RFC 7946)
+```
+
+`'unwrap'` shifts longitudes by multiples of 360° so the line never jumps the
+dateline (ideal for MapLibre/Leaflet/Deck.gl). `'split'` cuts the route into a
+`MultiLineString` at ±180°, keeping every coordinate in range. Both apply to
+`seaRoute` and `seaRouteMulti`; `properties.length` is unchanged either way.
 
 ## Restrictable passages
 
@@ -269,8 +286,10 @@ import {
   NoRouteError,
   // types
   type Passage,
+  type Antimeridian,
   type SeaRouteOptions,
   type SeaRouteFeature,
+  type SeaRouteMultiFeature,
   type SeaRouteProperties,
   type LoadNetworkOptions,
   type MarnetNetwork,

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -467,6 +467,92 @@ test('DEFAULT_MARNET loads the shared network asset', (t) => {
   // The Eurostat network carries native `pass` labels on canal/strait edges.
   t.true(DEFAULT_MARNET.features.some((f) => typeof f.properties?.pass === 'string'));
 });
+// ── Antimeridian output ──────────────────────────────────────────────────────
+
+function maxLonJump(coords: number[][]): number {
+  let max = 0;
+  for (let i = 1; i < coords.length; i++) {
+    max = Math.max(max, Math.abs(coords[i][0] - coords[i - 1][0]));
+  }
+  return max;
+}
+
+test('default output leaves a trans-Pacific route wrapped (big longitude jump)', (t) => {
+  const r = seaRoute(YOKOHAMA, LA, { units: 'kilometers' });
+  t.is(r.geometry.type, 'LineString');
+  // Wrapped to [-180, 180] it jumps ~360° across the dateline mid-Pacific.
+  t.true(maxLonJump(r.geometry.coordinates) > 300);
+});
+
+test("antimeridian 'unwrap' keeps a continuous LineString across the dateline", (t) => {
+  const def = seaRoute(YOKOHAMA, LA, { units: 'kilometers' });
+  const r = seaRoute(YOKOHAMA, LA, { units: 'kilometers', antimeridian: 'unwrap' });
+  t.is(r.geometry.type, 'LineString');
+  // No consecutive step jumps the dateline any more.
+  t.true(maxLonJump(r.geometry.coordinates) < 180);
+  // Some longitude runs past +180 (unwrapped continuation of the Pacific).
+  t.true(r.geometry.coordinates.some((c) => c[0] > 180));
+  // Same point count and latitudes; same computed length.
+  t.is(r.geometry.coordinates.length, def.geometry.coordinates.length);
+  t.deepEqual(
+    r.geometry.coordinates.map((c) => c[1]),
+    def.geometry.coordinates.map((c) => c[1]),
+  );
+  t.is(Math.round(r.properties.length), Math.round(def.properties.length));
+});
+
+test("antimeridian 'split' returns a MultiLineString cut at ±180°", (t) => {
+  const def = seaRoute(YOKOHAMA, LA, { units: 'kilometers' });
+  const r = seaRoute(YOKOHAMA, LA, { units: 'kilometers', antimeridian: 'split' });
+  t.is(r.geometry.type, 'MultiLineString');
+  const parts = r.geometry.coordinates;
+  t.true(parts.length >= 2, 'a trans-Pacific route splits into at least two parts');
+
+  for (const part of parts) {
+    for (const [lon] of part) t.true(Math.abs(lon) <= 180 + 1e-9, `lon ${lon} within ±180`);
+    t.true(maxLonJump(part) < 180, 'no part jumps the dateline internally');
+  }
+
+  // Each cut meets the dateline at ±180° with a shared latitude.
+  for (let i = 0; i < parts.length - 1; i++) {
+    const end = parts[i][parts[i].length - 1];
+    const start = parts[i + 1][0];
+    t.is(Math.abs(end[0]), 180);
+    t.is(Math.abs(start[0]), 180);
+    t.true(Math.abs(end[1] - start[1]) < 1e-9, 'cut latitude is continuous');
+  }
+
+  // The representation change does not alter the computed length.
+  t.is(Math.round(r.properties.length), Math.round(def.properties.length));
+});
+
+test('antimeridian options do not affect a route that never crosses the dateline', (t) => {
+  const def = seaRoute(NYC, LONDON, { units: 'kilometers' });
+  const unwrapped = seaRoute(NYC, LONDON, { units: 'kilometers', antimeridian: 'unwrap' });
+  t.deepEqual(unwrapped.geometry.coordinates, def.geometry.coordinates);
+
+  const split = seaRoute(NYC, LONDON, { units: 'kilometers', antimeridian: 'split' });
+  t.is(split.geometry.type, 'MultiLineString');
+  t.is(split.geometry.coordinates.length, 1);
+  t.deepEqual(split.geometry.coordinates[0], def.geometry.coordinates);
+});
+
+test('seaRouteMulti honours antimeridian: split across legs', (t) => {
+  const r = seaRouteMulti([YOKOHAMA, LA, NYC], { units: 'kilometers', antimeridian: 'split' });
+  t.is(r.geometry.type, 'MultiLineString');
+  t.true(r.geometry.coordinates.length >= 2);
+  for (const part of r.geometry.coordinates) {
+    for (const [lon] of part) t.true(Math.abs(lon) <= 180 + 1e-9);
+  }
+});
+
+test('seaRouteAlternatives ignores antimeridian and returns LineStrings', (t) => {
+  const alts = seaRouteAlternatives(YOKOHAMA, LA, {
+    units: 'kilometers',
+    antimeridian: 'split',
+  });
+  for (const a of alts) t.is(a.geometry.type, 'LineString');
+});
 
 // ── Custom network ──────────────────────────────────────────────────────────
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,21 @@
-import { feature as turfFeature, lineString, point as turfPoint } from '@turf/helpers';
+import {
+  feature as turfFeature,
+  lineString,
+  multiLineString,
+  point as turfPoint,
+} from '@turf/helpers';
 import type { Units } from '@turf/helpers';
 import length from '@turf/length';
-import type { Feature, LineString, Point, Position } from 'geojson';
+import type { Feature, LineString, MultiLineString, Point, Position } from 'geojson';
 
+import { type Antimeridian, splitAtAntimeridian, unwrapCoords } from './lib/antimeridian.js';
 import { passagesBlockedByDraft } from './lib/drafts.js';
 import { buildFinder, DEFAULT_MARNET, type MarnetNetwork } from './lib/finder.js';
 import { bboxOf, greatCircleKm } from './lib/metrics.js';
 import { type Passage, passagesAlong } from './lib/restrictions.js';
 import { snapToNetwork } from './lib/snap.js';
 
+export type { Antimeridian } from './lib/antimeridian.js';
 export type { Passage } from './lib/restrictions.js';
 export { PASSAGE_BBOXES } from './lib/restrictions.js';
 export type { MarnetProperties } from './lib/marnet.js';
@@ -77,6 +84,21 @@ export type SeaRouteOptions = {
    * `pass` string property on features for native passage restrictions.
    */
   network?: MarnetNetwork;
+  /**
+   * How to represent routes that cross the ±180° antimeridian (e.g. a
+   * trans-Pacific Yokohama → LA route). By default (`undefined`) the geometry
+   * is left wrapped to [-180, 180], which some map renderers draw as a straight
+   * streak across the whole map.
+   *
+   * - `'unwrap'` — one continuous `LineString`; longitudes are shifted by
+   *   multiples of 360° so the line never jumps the dateline (may exceed ±180°).
+   * - `'split'` — a `MultiLineString` cut at ±180°, keeping every coordinate
+   *   within ±180° (RFC 7946-friendly).
+   *
+   * Applies to `seaRoute` and `seaRouteMulti` output. `seaRouteAlternatives`
+   * always returns wrapped `LineString`s.
+   */
+  antimeridian?: Antimeridian;
 };
 
 export type SeaRouteProperties = {
@@ -103,6 +125,9 @@ export type SeaRouteProperties = {
 };
 
 export type SeaRouteFeature = Feature<LineString, SeaRouteProperties>;
+
+/** A route returned with `antimeridian: 'split'` — split into a MultiLineString. */
+export type SeaRouteMultiFeature = Feature<MultiLineString, SeaRouteProperties>;
 
 /** Thrown when no path exists between the snapped origin and destination. */
 export class NoRouteError extends Error {
@@ -142,8 +167,18 @@ function resolveRestrictions(options: SeaRouteOptions): Passage[] {
 export function seaRoute(
   origin: PointInput,
   destination: PointInput,
+  options: SeaRouteOptions & { antimeridian: 'split' },
+): SeaRouteMultiFeature;
+export function seaRoute(
+  origin: PointInput,
+  destination: PointInput,
+  unitsOrOptions?: Units | SeaRouteOptions,
+): SeaRouteFeature;
+export function seaRoute(
+  origin: PointInput,
+  destination: PointInput,
   unitsOrOptions: Units | SeaRouteOptions = 'nauticalmiles',
-): SeaRouteFeature {
+): SeaRouteFeature | SeaRouteMultiFeature {
   const options: SeaRouteOptions =
     typeof unitsOrOptions === 'string' ? { units: unitsOrOptions } : unitsOrOptions;
 
@@ -175,8 +210,7 @@ export function seaRoute(
   const lenKm = length(inWater, { units: 'kilometers' });
   const gcKm = greatCircleKm(originFeature.geometry.coordinates, destFeature.geometry.coordinates);
 
-  const ls = lineString(coords) as SeaRouteFeature;
-  ls.properties = {
+  const properties: SeaRouteProperties = {
     length: lenInUnits,
     units,
     bbox: bboxOf(inWaterCoords),
@@ -188,14 +222,14 @@ export function seaRoute(
 
   if (options.speedKnots && options.speedKnots > 0) {
     // 1 knot = 1.852 km/h
-    ls.properties.durationHours = lenKm / (options.speedKnots * 1.852);
+    properties.durationHours = lenKm / (options.speedKnots * 1.852);
   }
 
   if (options.returnPassages) {
-    ls.properties.passages = passagesAlong(result.path);
+    properties.passages = passagesAlong(result.path);
   }
 
-  return ls;
+  return buildRouteFeature(coords, properties, options.antimeridian);
 }
 
 /**
@@ -208,15 +242,23 @@ export function seaRoute(
  */
 export function seaRouteMulti(
   points: PointInput[],
+  options: SeaRouteOptions & { antimeridian: 'split' },
+): SeaRouteMultiFeature;
+export function seaRouteMulti(points: PointInput[], options?: SeaRouteOptions): SeaRouteFeature;
+export function seaRouteMulti(
+  points: PointInput[],
   options: SeaRouteOptions = {},
-): SeaRouteFeature {
+): SeaRouteFeature | SeaRouteMultiFeature {
   if (points.length < 2) {
     throw new Error('seaRouteMulti requires at least two waypoints');
   }
 
+  // Compute each leg as a plain wrapped LineString; the antimeridian option is
+  // applied once to the concatenated route so the legs still join cleanly.
+  const legOptions: SeaRouteOptions = { ...options, antimeridian: undefined };
   const legs: SeaRouteFeature[] = [];
   for (let i = 0; i < points.length - 1; i++) {
-    legs.push(seaRoute(points[i], points[i + 1], options));
+    legs.push(seaRoute(points[i], points[i + 1], legOptions));
   }
 
   // Concatenate legs without duplicating shared join vertices.
@@ -240,8 +282,7 @@ export function seaRouteMulti(
   }
   const totalKm = legs.reduce((s, l) => s + l.properties.length * unitToKm(l.properties.units), 0);
 
-  const ls = lineString(coords) as SeaRouteFeature;
-  ls.properties = {
+  const properties: SeaRouteProperties = {
     length: totalUnits,
     units,
     bbox: bboxOf(coords),
@@ -252,16 +293,16 @@ export function seaRouteMulti(
   };
 
   if (options.speedKnots && options.speedKnots > 0) {
-    ls.properties.durationHours = totalKm / (options.speedKnots * 1.852);
+    properties.durationHours = totalKm / (options.speedKnots * 1.852);
   }
 
   if (options.returnPassages) {
     const set = new Set<Passage>();
     for (const l of legs) for (const p of l.properties.passages ?? []) set.add(p);
-    ls.properties.passages = Array.from(set);
+    properties.passages = Array.from(set);
   }
 
-  return ls;
+  return buildRouteFeature(coords, properties, options.antimeridian);
 }
 
 export type SeaRouteAlternative = SeaRouteFeature & {
@@ -325,6 +366,10 @@ export function seaRouteAlternatives(
     try {
       const r = seaRoute(origin, destination, {
         ...options,
+        // Alternatives are compared and returned as wrapped LineStrings; the
+        // antimeridian representation is a per-route concern the caller can
+        // re-apply with seaRoute if needed.
+        antimeridian: undefined,
         restrictions: variantRestrictions,
         returnPassages: true,
       });
@@ -410,6 +455,28 @@ export async function loadNetwork(
 }
 
 // ── Internal helpers ────────────────────────────────────────────────────────
+
+/**
+ * Build the output feature from route coordinates, applying the antimeridian
+ * option: `'split'` yields a `MultiLineString` cut at ±180°, `'unwrap'` yields a
+ * continuous `LineString` (longitudes may exceed ±180°), and the default leaves
+ * the coordinates wrapped as computed.
+ */
+function buildRouteFeature(
+  coords: Position[],
+  properties: SeaRouteProperties,
+  antimeridian?: Antimeridian,
+): SeaRouteFeature | SeaRouteMultiFeature {
+  if (antimeridian === 'split') {
+    const ml = multiLineString(splitAtAntimeridian(coords)) as SeaRouteMultiFeature;
+    ml.properties = properties;
+    return ml;
+  }
+  const outCoords = antimeridian === 'unwrap' ? unwrapCoords(coords) : coords;
+  const ls = lineString(outCoords) as SeaRouteFeature;
+  ls.properties = properties;
+  return ls;
+}
 
 function unitToKm(u: Units): number {
   // Hard-code the conversions we care about; @turf doesn't export a helper.

--- a/src/lib/antimeridian.ts
+++ b/src/lib/antimeridian.ts
@@ -1,0 +1,108 @@
+import type { Position } from 'geojson';
+
+/**
+ * How to represent a route that crosses the ±180° antimeridian.
+ *
+ * - `'unwrap'` — keep a single continuous LineString, shifting longitudes by
+ *   multiples of 360° so consecutive points never jump the dateline. Some
+ *   longitudes may fall outside ±180°. This is what most web map renderers
+ *   (MapLibre, Leaflet, Deck.gl) want to draw the line the short way round.
+ * - `'split'` — cut the route into a `MultiLineString` at ±180°, so every
+ *   coordinate stays within ±180°. More correct for GeoJSON tooling that
+ *   follows RFC 7946.
+ */
+export type Antimeridian = 'unwrap' | 'split';
+
+/** Copy a position, replacing its longitude (preserving lat and any Z/extra dims). */
+function withLon(p: Position, lon: number): Position {
+  const out = p.slice();
+  out[0] = lon;
+  return out;
+}
+
+/**
+ * Shift each longitude by a multiple of 360° so that the step from the previous
+ * point is always the short way round, producing a continuous line across the
+ * antimeridian. Longitudes may exceed ±180°. Does not mutate the input, and
+ * returns lines that never cross the dateline unchanged.
+ */
+export function unwrapCoords(coords: Position[]): Position[] {
+  if (coords.length === 0) return [];
+  const out: Position[] = [coords[0].slice()];
+  let offset = 0;
+  for (let i = 1; i < coords.length; i++) {
+    let lon = coords[i][0] + offset;
+    const prev = out[i - 1][0];
+    while (lon - prev > 180) {
+      offset -= 360;
+      lon -= 360;
+    }
+    while (lon - prev <= -180) {
+      offset += 360;
+      lon += 360;
+    }
+    out.push(withLon(coords[i], lon));
+  }
+  return out;
+}
+
+/** Which 360°-wide panel a longitude falls in (panel boundaries at 180 + 360k). */
+function panelOf(lon: number): number {
+  return Math.floor((lon + 180) / 360);
+}
+
+/** Append a point unless it exactly repeats the segment's current last point. */
+function pushPoint(segment: Position[], p: Position): void {
+  const last = segment[segment.length - 1];
+  if (last && last[0] === p[0] && last[1] === p[1]) return;
+  segment.push(p);
+}
+
+/**
+ * Split a route into segments that each stay within ±180°, cutting at every
+ * antimeridian crossing and inserting the interpolated dateline point at both
+ * ends of the cut. Always returns at least one segment; a route that never
+ * crosses the dateline comes back as a single (longitude-wrapped) segment.
+ *
+ * Works on the unwrapped (continuous) coordinates, then brings each resulting
+ * sub-line back into ±180° by its panel offset. Vertices that sit exactly on
+ * the dateline (the bundled network normalizes ±180° vertices) are handled as
+ * crossings rather than being dropped.
+ */
+export function splitAtAntimeridian(coords: Position[]): Position[][] {
+  if (coords.length === 0) return [];
+
+  const u = unwrapCoords(coords);
+  const wrapInto = (p: Position, panel: number): Position => withLon(p, p[0] - 360 * panel);
+
+  const segments: Position[][] = [];
+  let panel = panelOf(u[0][0]);
+  let current: Position[] = [wrapInto(u[0], panel)];
+
+  for (let i = 1; i < u.length; i++) {
+    const prev = u[i - 1];
+    const cur = u[i];
+    const curPanel = panelOf(cur[0]);
+
+    if (curPanel === panel) {
+      pushPoint(current, wrapInto(cur, panel));
+      continue;
+    }
+
+    // Unwrapped steps are < 360°, so panels differ by exactly one: one crossing.
+    const dir = curPanel > panel ? 1 : -1;
+    const boundary = 180 + 360 * (dir > 0 ? panel : panel - 1);
+    const t = (boundary - prev[0]) / (cur[0] - prev[0]);
+    const lat = prev[1] + t * (cur[1] - prev[1]);
+
+    pushPoint(current, [boundary - 360 * panel, lat]); // +180 east, -180 west
+    segments.push(current);
+
+    panel = curPanel;
+    current = [[boundary - 360 * panel, lat]]; // -180 east, +180 west
+    pushPoint(current, wrapInto(cur, panel));
+  }
+
+  segments.push(current);
+  return segments;
+}


### PR DESCRIPTION
## Summary

Routes crossing the ±180° antimeridian (e.g. Yokohama → LA) come back wrapped to `[-180, 180]`, so a segment jumps from `+179` to `-179`. Fed straight into MapLibre / Leaflet / Deck.gl, that draws as a **straight streak across the whole map** instead of across the Pacific. This was already solved for our own demo (`examples/web-demo/src/geo.ts`); this PR moves the capability into the library so downstream map consumers don't each rediscover it.

## What changed

New `antimeridian` option on `seaRoute` and `seaRouteMulti`:

```ts
seaRoute(yokohama, la, { antimeridian: 'unwrap' }); // continuous coords (may exceed ±180)
seaRoute(yokohama, la, { antimeridian: 'split' });  // MultiLineString split at ±180
```

- **Default `undefined`** — current behaviour, wrapped `LineString` (no breaking change).
- **`'unwrap'`** — one continuous `LineString`; longitudes shifted by multiples of 360° so consecutive points never jump the dateline (the demo's approach).
- **`'split'`** — a `MultiLineString` cut at ±180°, keeping every coordinate within ±180° (RFC 7946-friendly), inserting the interpolated dateline point at both ends of each cut.

Details:
- New `src/lib/antimeridian.ts` with `unwrapCoords` / `splitAtAntimeridian`.
- Return types are narrowed by overload: `{ antimeridian: 'split' }` returns the new `SeaRouteMultiFeature` (`Feature<MultiLineString, …>`); everything else still returns `SeaRouteFeature`. So existing TS consumers see no type change.
- `seaRouteMulti` applies the option **once to the concatenated route** (legs are computed as plain wrapped LineStrings so they still join cleanly).
- `seaRouteAlternatives` continues to return wrapped `LineString`s (documented).
- `properties.length` and `bbox` are computed from the geodesic path and are unaffected by the representation.
- New exports: `Antimeridian`, `SeaRouteMultiFeature`. README / DOCS / CHANGELOG updated.

### One subtlety worth noting

The bundled network normalizes `lon === 180` vertices to `-180`, so a trans-Pacific route can pass through a vertex sitting **exactly** on the dateline. `splitAtAntimeridian` works in unwrapped space and assigns each sub-line a 360°-panel offset, so boundary-coincident vertices are handled as crossings (and de-duplicated) rather than being dropped — verified against Yokohama → LA (vertex on 180) and Sydney → Vancouver (interpolated crossing at lat 0).

## Validation

All steps CI runs, from a clean tree:

- `npm ci`
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run build` ✅
- `npm test` ✅ (50 tests; 6 new covering unwrap continuity, split cut points at ±180 with continuous latitude, all coords within ±180, non-crossing routes unchanged, `seaRouteMulti` split, and alternatives staying `LineString`)

Also verified end-to-end against the built `dist` (CJS + ESM) that unwrap removes all dateline jumps and split produces valid in-range `MultiLineString` geometry with length preserved.

Closes #9